### PR TITLE
JS fix

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -88,10 +88,10 @@ def parse(source, code):
 
             else:
                 multi_line = False
-
+					
             # Get rid of the delimeters so that they aren't in the final docs
-            line = re.sub(language["multistart"],'',line)
-            line = re.sub(language["multiend"],'',line)
+            line = re.sub(re.escape(language["multistart"]),'',line)
+            line = re.sub(re.escape(language["multiend"]),'',line)
             docs_text += line.strip() + '\n'
 
             if has_code and docs_text.strip():


### PR DESCRIPTION
JS was borked because pycco wasnt escaping the strings used for multiline start and end. this fix works.
