### PR TITLE
Fix bad handling of comments that use multiline delimiters surrounding a single line

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -88,6 +88,11 @@ def parse(source, code):
 
             else:
                 multi_line = False
+                
+            if (multi_line
+               and line.strip().endswith(language.get("multiend"))
+               and len(line.strip()) > len(language.get("multiend"))):
+                multi_line = False
 
             # Get rid of the delimiters so that they aren't in the final docs
             line = re.sub(re.escape(language["multistart"]),'',line)


### PR DESCRIPTION
I had this:

```
def my_func():
    """a docstring"""
    pass # some code
```

pycco opened a new comment but never closed it, so it flipped all the code and comments thereafter.
