### PR TITLE
fix JS multiline comment parsing error

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -97,15 +97,15 @@ def parse(source, code):
 
             else:
                 multi_line = False
-                
+
             if (multi_line
                and line.strip().endswith(language.get("multiend"))
                and len(line.strip()) > len(language.get("multiend"))):
                 multi_line = False
 
             # Get rid of the delimiters so that they aren't in the final docs
-            line = re.sub(re.escape(language["multistart"]),'',line)
-            line = re.sub(re.escape(language["multiend"]),'',line)
+            line = line.replace(language["multistart"], '')
+            line = line.replace(language["multiend"], '')
             docs_text += line.strip() + '\n'
             indent_level = re.match("\s*", line).group(0)
 


### PR DESCRIPTION
'multiend' for JS is an invalid regex
`re.sub('*/', '', '*/')` results in `sre_constants.error: nothing to repeat`

None of the multistart/multiend's look like regexs anyway, so just use string.replace.
