### PR TITLE
Add Rudimentary HTML Support

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -299,6 +299,11 @@ languages = {
         "multistart": "--[[", "multiend": "--]]"},
 
     ".erl": { "name": "erlang", "symbol": "%%" },
+
+    ".html": { "name": "html", "symbol": "HTMLDIVIDER",
+        "multistart": "<!--", "multiend": "-->",
+        "divider_text": "<!-- HTMLDIVIDER -->",
+        "divider_html": re.compile(r'\n*<span class="c[1]?">&lt;!-- HTMLDIVIDER --&gt;</span>\n*') },
 }
 
 # Build out the appropriate matchers and delimiters for each language.
@@ -308,11 +313,13 @@ for ext, l in languages.items():
 
     # The dividing token we feed into Pygments, to delimit the boundaries between
     # sections.
-    l["divider_text"] = "\n" + l["symbol"] + "DIVIDER\n"
+    if "divider_text" not in l:
+        l["divider_text"] = "\n" + l["symbol"] + "DIVIDER\n"
 
     # The mirror of `divider_text` that we expect Pygments to return. We can split
     # on this to recover the original sections.
-    l["divider_html"] = re.compile(r'\n*<span class="c[1]?">' + l["symbol"] + 'DIVIDER</span>\n*')
+    if "divider_html" not in l:
+        l["divider_html"] = re.compile(r'\n*<span class="c[1]?">' + l["symbol"] + 'DIVIDER</span>\n*')
 
     # Get the Pygments Lexer for this language.
     l["lexer"] = lexers.get_lexer_by_name(l["name"])


### PR DESCRIPTION
This is a great project! I used it for a project documenting how to integrate [Livefyre](http://www.livefyre.com) for our customers. It helped a lot!

I wanted to use it on an HTML document, though. So I added rudimentary HTML support for multiline comments. I couldn't do it with the built in symbol-only definition in the langs dict, so I added two lines to generate_html to let me explicitly define divider_text and divider_html.

You can see it in action here: http://demos.livefyre.com/ssosandbox/help/

I will probably have a need soon to add support for not needing to have a newline between the `<!--` and the actual comment, but I think that will be more invasive. Someone might be able to tweak a regex somewhere to do it easily. I didn't grok the whole program, but like I said, it's great!
