### PR TITLE
Fix background not staying behind the code when scrolling horizontally

### DIFF
--- a/pycco_resources/__init__.py
+++ b/pycco_resources/__init__.py
@@ -6,6 +6,7 @@ body {
   line-height: 24px;
   color: #252519;
   margin: 0; padding: 0;
+  background: #f5f5ff;
 }
 a {
   color: #261a3b;
@@ -22,15 +23,18 @@ h1, h2, h3, h4, h5, h6 {
 h2, h3, h4, h5, h6 {
     margin-top: 0;
   }
+#container {
+  background: white;
+ }
 #container, div.section {
   position: relative;
 }
 #background {
-  position: fixed;
+  position: absolute;
   top: 0; left: 580px; right: 0; bottom: 0;
   background: #f5f5ff;
   border-left: 1px solid #e5e5ee;
-  z-index: -1;
+  z-index: 0;
 }
 #jump_to, #jump_page {
   background: white;
@@ -196,8 +200,8 @@ html = """\
   <link rel="stylesheet" href="{{ stylesheet }}">
 </head>
 <body>
-<div id="background"></div>
 <div id='container'>
+  <div id="background"></div>
   {{#sources?}}
   <div id="jump_to">
     Jump To &hellip;


### PR DESCRIPTION
This commit fixes a bug introduced in e2032e19b05 which changed the
previous table layout to a pure CSS-based layout. Because the new layout
used a "position: fixed" background, the background would not scroll
when code lines were more wide than the browser window. This has been
fixed by making the background "position: absolute" and moving it into
the container DIV. Because the container DIV does not expand if its
content is wider than the browser window though, I had to set the body
background color to the same color than the code background and the
container background to white, so that the left (comment) part stays
white.

Screenshot before the fix:
![Before fix](http://cl.ly/0o2T3c2d01313T2x0r0s/before.png)

Screenshot after the fix:
![After fix](http://cl.ly/1w0o1C2Y1N3d3x3I0W3l/after.png)
