### PR TITLE
Allow doc string closing at the end of a line

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -91,7 +91,7 @@ def parse(source, code):
 
         # Only go into multiline comments section when one of the delimiters is
         # found to be at the start of a line
-        if all(multi_line_delimiters) and any([line.lstrip().startswith(delim) for delim in multi_line_delimiters]):
+        if all(multi_line_delimiters) and any([line.lstrip().startswith(delim) or line.rstrip().endswith(delim) for delim in multi_line_delimiters]):
             if not multi_line:
                 multi_line = True
 


### PR DESCRIPTION
Doc strings symbols can occur at the end of lines, as well as the start.
The style guide PEP prefers them at the start, but it's quite valid to have them at the end, and some people prefer that.

This patch allows you to close a doc string at the end of a line, instead of having to put the triple-quote on a new line by itself.
