### PR TITLE
Allow Pycco to take an additional stylesheet

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -34,7 +34,7 @@ Or, to install the latest source
 # === Main Documentation Generation Functions ===
 
 def generate_documentation(source, outdir=None, preserve_paths=True,
-                           language=None):
+                           language=None, additional_stylesheet=None):
     """
     Generate the documentation for a source file by reading it in, splitting it
     up into comment/code sections, highlighting them for the appropriate
@@ -47,7 +47,7 @@ def generate_documentation(source, outdir=None, preserve_paths=True,
     language = get_language(source, code, language=language)
     sections = parse(source, code, language)
     highlight(source, sections, language, preserve_paths=preserve_paths, outdir=outdir)
-    return generate_html(source, sections, preserve_paths=preserve_paths, outdir=outdir)
+    return generate_html(source, sections, preserve_paths=preserve_paths, outdir=outdir, additional_stylesheet=additional_stylesheet)
 
 def parse(source, code, language):
     """
@@ -223,7 +223,7 @@ def highlight(source, sections, language, preserve_paths=True, outdir=None):
 
 # === HTML Code generation ===
 
-def generate_html(source, sections, preserve_paths=True, outdir=None):
+def generate_html(source, sections, preserve_paths=True, outdir=None, additional_stylesheet=None):
     """
     Once all of the code is finished highlighting, we can generate the HTML file
     and write out the documentation. Pass the completed sections into the
@@ -247,6 +247,7 @@ def generate_html(source, sections, preserve_paths=True, outdir=None):
     rendered = pycco_template({
         "title"       : title,
         "stylesheet"  : csspath,
+        "additional_stylesheet"  : additional_stylesheet,
         "sections"    : sections,
         "source"      : source,
         "path"        : path,
@@ -400,7 +401,7 @@ highlight_start = "<div class=\"highlight\"><pre>"
 # The end of each Pygments highlight block.
 highlight_end = "</pre></div>"
 
-def process(sources, preserve_paths=True, outdir=None, language=None):
+def process(sources, preserve_paths=True, outdir=None, language=None, additional_stylesheet=None):
     """For each source file passed as argument, generate the documentation."""
 
     if not outdir:
@@ -413,6 +414,7 @@ def process(sources, preserve_paths=True, outdir=None, language=None):
     # Proceed to generating the documentation.
     if sources:
         ensure_directory(outdir)
+
         css = open(path.join(outdir, "pycco.css"), "w")
         css.write(pycco_styles)
         css.close()
@@ -428,7 +430,7 @@ def process(sources, preserve_paths=True, outdir=None, language=None):
 
             with open(dest, "w") as f:
                 f.write(generate_documentation(s, preserve_paths=preserve_paths, outdir=outdir,
-                                               language=language))
+                                               language=language, additional_stylesheet=additional_stylesheet))
 
             print "pycco = %s -> %s" % (s, dest)
 
@@ -499,10 +501,15 @@ def main():
     parser.add_option('-l', '--force-language', action='store', type='string',
                       dest='language', default=None,
                       help='Force the language for the given files')
+
+    parser.add_option('-s', '--stylesheet', action='store', type='string',
+                      dest='additional_stylesheet', default=None,
+                      help='An additional css file to apply')
+
     opts, sources = parser.parse_args()
 
     process(sources, outdir=opts.outdir, preserve_paths=opts.paths,
-            language=opts.language)
+            language=opts.language, additional_stylesheet=opts.additional_stylesheet)
 
     # If the -w / --watch option was present, monitor the source directories
     # for changes and re-generate documentation for source files whenever they

--- a/pycco_resources/__init__.py
+++ b/pycco_resources/__init__.py
@@ -198,6 +198,9 @@ html = """\
   <meta http-equiv="content-type" content="text/html;charset=utf-8">
   <title>{{ title }}</title>
   <link rel="stylesheet" href="{{ stylesheet }}">
+  {{#additional_stylesheet}}
+    <link rel="stylesheet" href="{{ additional_stylesheet }}">
+  {{/additional_stylesheet}}
 </head>
 <body>
 <div id='container'>


### PR DESCRIPTION
This merge allows pycco to take an additional parameter on the console via the -s or --stylesheet option. The option requires a parameter if used, and should be the file path for the additional stylesheet. If the stylesheet is supplied, it is inserted into the template after the default pycco styles.

This pull request also adds SASS as a supported language.
