### PR TITLE
added opencl and improved some debug output

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -288,6 +288,9 @@ languages = {
 
     ".cpp": { "name": "cpp", "symbol": "//"},
 
+    ".cl":   { "name": "c", "symbol": "//",
+        "multistart": "/*", "multiend": "*/"},
+
     ".js": { "name": "javascript", "symbol": "//",
         "multistart": "/*", "multiend": "*/"},
 
@@ -346,7 +349,7 @@ def get_language(source, code, language=None):
             if l["name"] == lang:
                 return l
         else:
-            raise ValueError("Can't figure out the language!")
+            raise ValueError("Can't figure out the language! of %s" % source)
 
 def destination(filepath, preserve_paths=True, outdir=None):
     """
@@ -416,6 +419,7 @@ def process(sources, preserve_paths=True, outdir=None, language=None):
 
         def next_file():
             s = sources.pop(0)
+            print "pycco = %s ->" % s,
             dest = destination(s, preserve_paths=preserve_paths, outdir=outdir)
 
             try:
@@ -427,7 +431,7 @@ def process(sources, preserve_paths=True, outdir=None, language=None):
                 f.write(generate_documentation(s, preserve_paths=preserve_paths, outdir=outdir,
                                                language=language))
 
-            print "pycco = %s -> %s" % (s, dest)
+            print dest
 
             if sources:
                 next_file()

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -43,11 +43,11 @@ def generate_documentation(source, encoding, outdir=None, preserve_paths=True,
 
     if not outdir:
         raise TypeError("Missing the required 'outdir' keyword argument.")
-    code = open(source, "r").read()
+    code = codecs.open(source, "r", encoding).read()
     language = get_language(source, code, language=language)
     sections = parse(source, code, language)
-    highlight(source, sections, language, encoding, preserve_paths=preserve_paths, outdir=outdir)
-    return generate_html(source, sections, preserve_paths=preserve_paths, outdir=outdir)
+    highlight(source, sections, language, preserve_paths=preserve_paths, outdir=outdir)
+    return generate_html(source, encoding, sections, preserve_paths=preserve_paths, outdir=outdir)
 
 def parse(source, code, language):
     """
@@ -190,7 +190,7 @@ def preprocess(comment, section_nr, preserve_paths=True, outdir=None):
 
 # === Highlighting the source code ===
 
-def highlight(source, sections, language, encoding, preserve_paths=True, outdir=None):
+def highlight(source, sections, language, preserve_paths=True, outdir=None):
     """
     Highlights a single chunk of code using the **Pygments** module, and runs
     the text of its corresponding comment through **Markdown**.
@@ -211,10 +211,7 @@ def highlight(source, sections, language, encoding, preserve_paths=True, outdir=
     fragments = re.split(language["divider_html"], output)
     for i, section in enumerate(sections):
         section["code_html"] = highlight_start + shift(fragments, "") + highlight_end
-        try:
-            docs_text = unicode(section["docs_text"])
-        except UnicodeError:
-            docs_text = unicode(section["docs_text"].decode(encoding))
+        docs_text = unicode(section["docs_text"])
         section["docs_html"] = markdown(preprocess(docs_text,
                                                    i,
                                                    preserve_paths=preserve_paths,
@@ -223,7 +220,7 @@ def highlight(source, sections, language, encoding, preserve_paths=True, outdir=
 
 # === HTML Code generation ===
 
-def generate_html(source, sections, preserve_paths=True, outdir=None):
+def generate_html(source, encoding, sections, preserve_paths=True, outdir=None):
     """
     Once all of the code is finished highlighting, we can generate the HTML file
     and write out the documentation. Pass the completed sections into the
@@ -245,7 +242,7 @@ def generate_html(source, sections, preserve_paths=True, outdir=None):
         sect["code_html"] = re.sub(r"\{\{", r"__DOUBLE_OPEN_STACHE__", sect["code_html"])
 
     rendered = pycco_template({
-        "title"       : title,
+        "title"       : unicode(title, encoding),
         "stylesheet"  : csspath,
         "sections"    : sections,
         "source"      : source,
@@ -271,6 +268,7 @@ import time
 from markdown import markdown
 from os import path
 from pygments import lexers, formatters
+import codecs
 
 # A list of the languages that Pycco supports, mapping the file extension to
 # the name of the Pygments lexer and the symbol that indicates a comment. To

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -423,18 +423,23 @@ def process(sources, preserve_paths=True, outdir=None, language=None):
         def next_file():
             s = sources.pop(0)
             print "pycco = %s ->" % s,
-            dest = destination(s, preserve_paths=preserve_paths, outdir=outdir)
 
-            try:
-                os.makedirs(path.split(dest)[0])
-            except OSError:
-                pass
+            if os.path.isdir(s):
+                sources.extend([os.path.join(s, c) for c in os.listdir(s)])
 
-            with open(dest, "w") as f:
-                f.write(generate_documentation(s, preserve_paths=preserve_paths, outdir=outdir,
-                                               language=language))
+            else:
+                dest = destination(s, preserve_paths=preserve_paths, outdir=outdir)
 
-            print dest
+                try:
+                    os.makedirs(path.split(dest)[0])
+                except OSError:
+                    pass
+
+                with open(dest, "w") as f:
+                    f.write(generate_documentation(s, preserve_paths=preserve_paths, outdir=outdir,
+                                                   language=language))
+
+                print dest
 
             if sources:
                 next_file()
@@ -503,6 +508,7 @@ def main():
     parser.add_option('-l', '--force-language', action='store', type='string',
                       dest='language', default=None,
                       help='Force the language for the given files')
+    parser.add_option('-r', '--recursive', action='store_true')
     opts, sources = parser.parse_args()
 
     process(sources, outdir=opts.outdir, preserve_paths=opts.paths,

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -33,7 +33,7 @@ Or, to install the latest source
 
 # === Main Documentation Generation Functions ===
 
-def generate_documentation(source, outdir=None, preserve_paths=True,
+def generate_documentation(source, encoding, outdir=None, preserve_paths=True,
                            language=None):
     """
     Generate the documentation for a source file by reading it in, splitting it
@@ -46,7 +46,7 @@ def generate_documentation(source, outdir=None, preserve_paths=True,
     code = open(source, "r").read()
     language = get_language(source, code, language=language)
     sections = parse(source, code, language)
-    highlight(source, sections, language, preserve_paths=preserve_paths, outdir=outdir)
+    highlight(source, sections, language, encoding, preserve_paths=preserve_paths, outdir=outdir)
     return generate_html(source, sections, preserve_paths=preserve_paths, outdir=outdir)
 
 def parse(source, code, language):
@@ -190,7 +190,7 @@ def preprocess(comment, section_nr, preserve_paths=True, outdir=None):
 
 # === Highlighting the source code ===
 
-def highlight(source, sections, language, preserve_paths=True, outdir=None):
+def highlight(source, sections, language, encoding, preserve_paths=True, outdir=None):
     """
     Highlights a single chunk of code using the **Pygments** module, and runs
     the text of its corresponding comment through **Markdown**.
@@ -214,7 +214,7 @@ def highlight(source, sections, language, preserve_paths=True, outdir=None):
         try:
             docs_text = unicode(section["docs_text"])
         except UnicodeError:
-            docs_text = unicode(section["docs_text"].decode('utf-8'))
+            docs_text = unicode(section["docs_text"].decode(encoding))
         section["docs_html"] = markdown(preprocess(docs_text,
                                                    i,
                                                    preserve_paths=preserve_paths,
@@ -403,7 +403,7 @@ highlight_start = "<div class=\"highlight\"><pre>"
 # The end of each Pygments highlight block.
 highlight_end = "</pre></div>"
 
-def process(sources, preserve_paths=True, outdir=None, language=None):
+def process(sources, encoding, preserve_paths=True, outdir=None, language=None):
     """For each source file passed as argument, generate the documentation."""
 
     if not outdir:
@@ -436,7 +436,7 @@ def process(sources, preserve_paths=True, outdir=None, language=None):
                     pass
 
                 with open(dest, "w") as f:
-                    f.write(generate_documentation(s, preserve_paths=preserve_paths, outdir=outdir,
+                    f.write(generate_documentation(s, encoding, preserve_paths=preserve_paths, outdir=outdir,
                                                    language=language))
 
                 print dest
@@ -508,10 +508,13 @@ def main():
     parser.add_option('-l', '--force-language', action='store', type='string',
                       dest='language', default=None,
                       help='Force the language for the given files')
-    parser.add_option('-r', '--recursive', action='store_true')
+    parser.add_option('-e', '--encoding', action='store', type='string',
+                      default='utf-8',
+                      help='The encoding of the source files')
+
     opts, sources = parser.parse_args()
 
-    process(sources, outdir=opts.outdir, preserve_paths=opts.paths,
+    process(sources, opts.encoding, outdir=opts.outdir, preserve_paths=opts.paths,
             language=opts.language)
 
     # If the -w / --watch option was present, monitor the source directories

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -286,6 +286,9 @@ languages = {
     ".c":   { "name": "c", "symbol": "//",
         "multistart": "/*", "multiend": "*/"},
 
+    ".h":   { "name": "c", "symbol": "//",
+        "multistart": "/*", "multiend": "*/"},
+
     ".cpp": { "name": "cpp", "symbol": "//"},
 
     ".cl":   { "name": "c", "symbol": "//",

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -421,7 +421,7 @@ def process(sources, encoding, preserve_paths=True, outdir=None, language=None, 
         css.write(pycco_styles)
         css.close()
 
-        def next_file():
+        while sources:
             s = sources.pop(0)
             print "pycco = %s ->" % s,
 
@@ -446,9 +446,6 @@ def process(sources, encoding, preserve_paths=True, outdir=None, language=None, 
 
                     print dest
 
-            if sources:
-                next_file()
-        next_file()
 
 __all__ = ("process", "generate_documentation")
 


### PR DESCRIPTION
- .cl files use the same syntax as c.
- If the language is not figured out, the path is part of the error message.
- If something goes wrong (for example broken encoding) the causing file is visible in the output.