### PR TITLE
Adds tox tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,20 @@
+sudo: false
 language: python
 python:
     - '2.7'
     - '3.5'
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+      install: tox
+      script: tox
+    - python: 3.6
+      env: TOXENV=py36
+      install: tox
+      script: tox
+    - python: 3.5
+      env: CODESTYLE=true
 install:
     - 'pip install -r requirements.txt'
     - 'pip install -r requirements.test.txt'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,6 @@ language: python
 python:
     - '2.7'
     - '3.5'
-matrix:
-  include:
-    - python: 2.7
-      env: TOXENV=py27
-      install: pip install tox
-      script: tox
-    - python: 3.6
-      env: TOXENV=py36
-      install: pip install tox
-      script: tox
-    - python: 3.5
-      env: CODESTYLE=true
 install:
     - 'pip install -r requirements.txt'
     - 'pip install -r requirements.test.txt'
@@ -23,3 +11,15 @@ script:
     - 'python -m pycco.main pycco/main.py'
 after_success:
     - coveralls
+matrix:
+  include:
+    - python: 3.5
+      env: CODESTYLE=true
+    - python: 2.7
+      env: TOXENV=py27
+      install: pip install tox
+      script: tox
+    - python: 3.6
+      env: TOXENV=py36
+      install: pip install tox
+      script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-      install: tox
+      install: pip install tox
       script: tox
     - python: 3.6
       env: TOXENV=py36
-      install: tox
+      install: pip install tox
       script: tox
     - python: 3.5
       env: CODESTYLE=true

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -535,6 +535,7 @@ def process(sources, preserve_paths=True, outdir=None, language=None,
             with open(path.join(outdir, "index.html"), "wb") as f:
                 f.write(generate_index.generate_index(generated_files, outdir))
 
+
 __all__ = ("process", "generate_documentation")
 
 
@@ -629,6 +630,7 @@ def main():
             sys.exit('The -w/--watch option requires the watchdog package.')
 
         monitor(sources, opts)
+
 
 # Run the script.
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist = py2,py3,codestyle
 
 [testenv]
 deps = -rrequirements.test.txt
-commands = py.test
+commands = pytest
 
 [testenv:codestyle]
 deps = pycodestyle
 # E501 - line too long
-commands = pycodestyle --ignore=E501
+commands = pycodestyle --ignore=E501 pycco

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py2,py3,codestyle
+envlist = py27,py36,codestyle
 
 [testenv]
 deps = -rrequirements.test.txt


### PR DESCRIPTION
- Adds tox tests to travis. [What is tox?](https://tox.readthedocs.io/en/latest/#what-is-tox)
- updates tox to use python 3.6
- makes tox environments more specific
- codestyle only looks at the pycco subfolder

I left out updating the rest of the travis config to 3.6. 
@subsetpark what do you think of moving the rest of the file to tox centric tests?