### PR TITLE
Option --skip-bad-files now skips all kind of bad files

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -605,7 +605,9 @@ def main():
     parser.add_option('-i', '--generate_index', action='store_true',
                       help='Generate an index.html document with sitemap content')
 
-    parser.add_option('-s', '--skip-bad-files', action='store_true',
+    parser.add_option('-s', '--skip-bad-files',
+                      '-e', '--ignore-errors',
+                      action='store_true',
                       dest='skip_bad_files',
                       help='Continue processing after hitting a bad file')
 

--- a/pycco/main.py
+++ b/pycco/main.py
@@ -521,9 +521,9 @@ def process(sources, preserve_paths=True, outdir=None, language=None,
 
                 print("pycco: {} -> {}".format(s, dest))
                 generated_files.append(dest)
-            except UnicodeDecodeError:
+            except (ValueError, UnicodeDecodeError) as e:
                 if skip:
-                    print("pycco [FAILURE]: {}".format(s))
+                    print("pycco [FAILURE]: {}, {}".format(s, e))
                 else:
                     raise
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,3 +1,4 @@
 hypothesis==1.18.1
-pytest-cov==2.2.0
+pytest-cov~=2.0
 coveralls==1.1
+mock~=2.0

--- a/tests/test_pycco.py
+++ b/tests/test_pycco.py
@@ -4,7 +4,10 @@ import tempfile
 import time
 import os.path
 import pytest
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from hypothesis import given, example, assume
 from hypothesis.strategies import lists, text, booleans, choices, none
 

--- a/tests/test_pycco.py
+++ b/tests/test_pycco.py
@@ -4,6 +4,7 @@ import tempfile
 import time
 import os.path
 import pytest
+from unittest.mock import patch
 from hypothesis import given, example, assume
 from hypothesis.strategies import lists, text, booleans, choices, none
 
@@ -158,6 +159,18 @@ def test_process(preserve_paths, index, choice):
               index=index,
               outdir=tempfile.gettempdir(),
               language=lang_name)
+
+
+@patch('pygments.lexers.guess_lexer')
+def test_process_skips_unknown_languages(mock_guess_lexer):
+    class Name:
+        name = 'this language does not exist'
+    mock_guess_lexer.return_value = Name()
+
+    with pytest.raises(ValueError):
+        p.process(['LICENSE'], outdir=tempfile.gettempdir(), skip=False)
+
+    p.process(['LICENSE'], outdir=tempfile.gettempdir(), skip=True)
 
 
 @given(lists(lists(text(min_size=1), min_size=1, max_size=30), min_size=1), lists(text(min_size=1), min_size=1))


### PR DESCRIPTION
I had some problems running `pycco` in a directory containing some cached Pytest files (`.pytest_cache/`). I noticed that even if the `--skip-bad-files` option was used, Pycco would still fail to generate the documentation. Removing the cached files is an option of course, but in my opinion Pycco should treat those files as *bad files*.

Given a `.pytest_cache` dire.tory (AFAIK it should be generate by Pytest when running the tests), the new behavior is the following,

## With the `--skip-bad-files` option
```
 ~/r/pycco git:(master) ✗ ➜ pycco --skip-bad-files  .pytest_cache/
pycco [FAILURE]: .pytest_cache/v/cache/lastfailed, Can't figure out the language!
pycco [FAILURE]: .pytest_cache/v/cache/nodeids, Can't figure out the language!
```

## Without the `--skip-bad-files` option
```
 ~/r/pycco git:(master) ✗ ➜ pycco .pytest_cache/
Traceback (most recent call last):
  File "/home/vrde/repos/pycco/pycco/main.py", line 392, in get_language
    lang = lexers.guess_lexer(code).name.lower()
  File "/home/vrde/.local/share/virtualenvs/1e40936ec5d4128/lib/python3.6/site-packages/pygments/lexers/__init__.py", line 252, in guess_lexer
    raise ClassNotFound('no lexer matching the text found')
pygments.util.ClassNotFound: no lexer matching the text found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vrde/.local/share/virtualenvs/1e40936ec5d4128/bin/pycco", line 11, in <module>
    load_entry_point('Pycco', 'console_scripts', 'pycco')()
  File "/home/vrde/repos/pycco/pycco/main.py", line 620, in main
    skip=opts.skip_bad_files)
  File "/home/vrde/repos/pycco/pycco/main.py", line 532, in process
    next_file()
  File "/home/vrde/repos/pycco/pycco/main.py", line 520, in next_file
    encoding=encoding))
  File "/home/vrde/repos/pycco/pycco/main.py", line 65, in generate_documentation
    return _generate_documentation(source, code, outdir, preserve_paths, language)
  File "/home/vrde/repos/pycco/pycco/main.py", line 72, in _generate_documentation
    language = get_language(file_path, code, language=language)
  File "/home/vrde/repos/pycco/pycco/main.py", line 402, in get_language
    raise ValueError("Can't figure out the language!")
ValueError: Can't figure out the language!
```