### PR TITLE
Fix overflow behaviour of long `pre` tags

### DIFF
--- a/pycco_resources/__init__.py
+++ b/pycco_resources/__init__.py
@@ -86,6 +86,7 @@ div.docs {
   .docs pre {
     margin: 15px 0 15px;
     padding-left: 15px;
+    overflow-y: scroll;
   }
   .docs p tt, .docs p code {
     background: #f8f8ff;


### PR DESCRIPTION
This is a very simple fix (only one line) that disables long content overflowing into the code area. This adds the ability of this long horizontal `pre` content to be horizontally scrollable.
**Before:**
![image](https://user-images.githubusercontent.com/5097028/66296304-d5b24980-e91f-11e9-93ff-45352cdeed60.png)

**After:**
![image](https://user-images.githubusercontent.com/5097028/66296277-c59a6a00-e91f-11e9-95a7-c08b94f16be0.png)
(Horizontally scrollable)

Please do let me know if you have any questions :)
