### PR TITLE
Project with many files will raise RecursionError

### DIFF
--- a/pycco/main.py
+++ b/pycco/main.py
@@ -504,8 +504,7 @@ def process(sources, preserve_paths=True, outdir=None, language=None,
 
         generated_files = []
 
-        def next_file():
-            s = sources.pop(0)
+        for s in sources:
             dest = destination(s, preserve_paths=preserve_paths, outdir=outdir)
 
             try:
@@ -527,10 +526,6 @@ def process(sources, preserve_paths=True, outdir=None, language=None,
                     print("pycco [FAILURE]: {}, {}".format(s, e))
                 else:
                     raise
-
-            if sources:
-                next_file()
-        next_file()
 
         if index:
             with open(path.join(outdir, "index.html"), "wb") as f:


### PR DESCRIPTION
use iteration instead of recursion to avoid exceeding python's recursion max depth when documenting large projects.

https://github.com/pycco-docs/pycco/issues/104

I was trying this project to document a very bulky project and stumbled upon the same issue, this doesn't change but the recursion method of `next_file`